### PR TITLE
Update version of cfn-policy-validator to 0.0.34

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # FROM public.ecr.aws/lambda/python:3.10
 FROM python:3.10
 # Install cfn-policy-validator
-RUN  pip install cfn-policy-validator==0.0.33
+RUN  pip install cfn-policy-validator==0.0.34
 
 COPY main.py /main.py
 


### PR DESCRIPTION
*Description of changes:*
Update version of `cfn-policy-validator` to 0.0.34 (bugfix: https://github.com/awslabs/aws-cloudformation-iam-policy-validator/pull/45)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
