### PR TITLE
Update version of cfn-policy-validator to 0.0.36

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # FROM public.ecr.aws/lambda/python:3.10
 FROM python:3.10
 # Install cfn-policy-validator
-RUN  pip install cfn-policy-validator==0.0.34
+RUN  pip install cfn-policy-validator==0.0.36
 
 COPY main.py /main.py
 


### PR DESCRIPTION
*Description of changes:*
Updating the version of cfn-policy-validator. The new version will support the following resource types  in check-no-public-access api.

[AWS::S3Tables::TableBucket](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-s3tables-tablebucket.html)
[AWS::ApiGateway::RestApi](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-restapi.html)
[AWS::CodeArtifact::Domain](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codeartifact-domain.html)
[AWS::Backup::BackupVault](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-backup-backupvault.html)
[AWS::CloudTrail::Dashboard](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudtrail-dashboard.html)
[AWS::CloudTrail::EventDataStore](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudtrail-eventdatastore.html)
[AWS::S3Express::AccessPoint](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-s3express-accesspoint.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
